### PR TITLE
Migrate to alpine and drop multi image dependency

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,8 +1,8 @@
-FROM docker.io/python:3.13-alpine
+FROM ghcr.io/astral-sh/uv:python3.13-alpine
 WORKDIR /app
 COPY fcwebapp fcwebapp/
 COPY config.env.py .
 COPY requirements.txt .
-RUN pip install uv && uv pip install -r requirements.txt --system
+RUN uv pip install -r requirements.txt --system
 EXPOSE 8000
 ENTRYPOINT ["gunicorn", "-b", "0.0.0.0:8000", "fcwebapp:app"]

--- a/Containerfile
+++ b/Containerfile
@@ -1,9 +1,8 @@
-FROM docker.io/python:3.13-slim
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+FROM docker.io/python:3.13-alpine
 WORKDIR /app
 COPY fcwebapp fcwebapp/
 COPY config.env.py .
 COPY requirements.txt .
-RUN uv pip install -r requirements.txt --system
+RUN pip install uv && uv pip install -r requirements.txt --system
 EXPOSE 8000
 ENTRYPOINT ["gunicorn", "-b", "0.0.0.0:8000", "fcwebapp:app"]


### PR DESCRIPTION
Alpine is smaller and has less vulnerabilities.

UV included in image as well.