### PR TITLE
disallow non-digit characters in phone numbers

### DIFF
--- a/fcwebapp/__init__.py
+++ b/fcwebapp/__init__.py
@@ -136,7 +136,8 @@ def profile_edit(user: UserInfo):
         match k:
             case "phone_number":
                 num = re.sub("\\D", "", v)
-                if len(num) < 10:
+                # shortest phone number 9 (Sweden) longest phone number 15 (E.164)
+                if len(num) < 9 or len(num) > 15:
                     return redirect('/profile',code=302)
                 else:
                     user.phone_number = num

--- a/fcwebapp/__init__.py
+++ b/fcwebapp/__init__.py
@@ -1,4 +1,5 @@
 import os
+import re
 import uuid
 from datetime import datetime
 
@@ -133,9 +134,12 @@ def profile_edit(user: UserInfo):
     for k, v in request.form.items():
         print(k, v)
         match k:
-            case 'phone_number':
-                num = v.strip().replace(' ', '').replace('-', '').replace('_', '')
-                user.phone_number = num
+            case "phone_number":
+                num = re.sub("\\D", "", v)
+                if len(num) < 10:
+                    return redirect('/profile',code=302)
+                else:
+                    user.phone_number = num
             case 'allergy':
                 user.allergy = v
             case 'diet':


### PR DESCRIPTION
Use regex to remove strings from a phone number and don't save the phone number if it's less than 9 digits or greater than 15
